### PR TITLE
Fix path of auto.sh in chruby.sh

### DIFF
--- a/chruby.sh
+++ b/chruby.sh
@@ -1,4 +1,4 @@
 if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
   source /usr/local/share/chruby/chruby.sh
-  source /usr/local/chruby/share/chruby/auto.sh
+  source /usr/local/share/chruby/auto.sh
 fi


### PR DESCRIPTION
I used your Dockerfile as a base for one of my Ruby projects when I noticed that chruby wasn't working. Shell session inside the container:

```
$ chruby rbx
/bin/bash: line 3: chruby: command not found
$ source /etc/profile.d/chruby.sh
/etc/profile.d/chruby.sh: line 3: /usr/local/chruby/share/chruby/auto.sh: No such file or directory
$ cat /etc/profile.d/chruby.sh
if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
  source /usr/local/share/chruby/chruby.sh
  source /usr/local/chruby/share/chruby/auto.sh
fi
$ source /usr/local/share/chruby/chruby.sh
$ source /usr/local/share/chruby/auto.sh
$ chruby rbx
$ which ruby
/opt/rubies/rbx-2.2.9/bin/ruby
```

As shown a simple correction to the path in chruby.sh fixes it.
